### PR TITLE
Fix vague model spec

### DIFF
--- a/lib/specMgr.js
+++ b/lib/specMgr.js
@@ -53,7 +53,8 @@ load = function(ctx, params, spec, idx, deps, cb, userData){
 		f = find(s[VALUE], ctx, true)
 		if (!f) return cb(ERR1.replace('REF', s[VALUE]), deps, params, userData)
 		var e = s[EXTRA]
-		var m = e.charAt ? f[VALUE].get(params[e]) : f[VALUE].at(e)
+		e = 'string' === typeof e ? e : params[e]
+		var m = 'string' === typeof e ? f[VALUE].get(e) : f[VALUE].at(e)
 		if (!m) return cb(ERR2.replace('REF', s[VALUE]).replace('RECORD',e), deps, params, userData)
 		deps.push(create(s[ID], t, m)) 
 		break

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pico-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "pico client",
   "main": "create",
   "repository": {


### PR DESCRIPTION
before this get model from models with spec has this implicit logic
- spec value is string or not string
- if resultant extra is string use coll.get, if not use coll.at

this PR make the logic more explicitly
- if spec extra is string, set `e` as extra
- if not use the number, set `e` as params[e]
- if e is string, use coll.get
- if e is number, use coll.at